### PR TITLE
Update task's due date when postponing a reminder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,19 +42,7 @@ proguard/
 captures/
 
 # IntelliJ
-*.iml
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/gradle.xml
-.idea/assetWizardSettings.xml
-.idea/dictionaries
-.idea/libraries
-.idea/jarRepositories.xml
-# Android Studio 3 in .gitignore file.
-.idea/caches
-.idea/modules.xml
-# Comment next line if keeping position of elements in Navigation Editor is relevant for you
-.idea/navEditor.xml
+.idea/
 
 # Keystore files
 *.jks

--- a/common/tasks/src/main/java/com/costular/atomtasks/tasks/interactor/PostponeTaskUseCase.kt
+++ b/common/tasks/src/main/java/com/costular/atomtasks/tasks/interactor/PostponeTaskUseCase.kt
@@ -14,6 +14,7 @@ class PostponeTaskUseCase @Inject constructor(
     private val getTaskByIdInteractor: GetTaskByIdInteractor,
     private val updateTaskReminderInteractor: UpdateTaskReminderInteractor,
     private val taskReminderManager: TaskReminderManager,
+    private val updateTaskUseCase: UpdateTaskUseCase,
 ) : UseCase<PostponeTaskUseCase.Params, Either<PostponeTaskFailure, Unit>> {
 
     data class Params(
@@ -32,6 +33,14 @@ class PostponeTaskUseCase @Inject constructor(
                 return PostponeTaskFailure.MissingReminder.toError()
             }
 
+            updateTaskUseCase.invoke(
+                UpdateTaskUseCase.Params(
+                    taskId = task.id,
+                    name = task.name,
+                    date = params.day,
+                    reminderTime = params.time,
+                )
+            )
             updateTaskReminderInteractor(
                 UpdateTaskReminderInteractor.Params(
                     taskId = params.taskId,
@@ -39,6 +48,7 @@ class PostponeTaskUseCase @Inject constructor(
                     date = params.day,
                 ),
             )
+
             taskReminderManager.set(
                 taskId = task.id,
                 localDateTime = params.day.atTime(params.time)

--- a/common/tasks/src/test/java/com/costular/atomtasks/tasks/interactor/PostponeTaskUseCaseTest.kt
+++ b/common/tasks/src/test/java/com/costular/atomtasks/tasks/interactor/PostponeTaskUseCaseTest.kt
@@ -1,8 +1,8 @@
 package com.costular.atomtasks.tasks.interactor
 
+import com.costular.atomtasks.tasks.manager.TaskReminderManager
 import com.costular.atomtasks.tasks.model.Reminder
 import com.costular.atomtasks.tasks.model.Task
-import com.costular.atomtasks.tasks.manager.TaskReminderManager
 import com.costular.core.toError
 import com.google.common.truth.Truth
 import io.mockk.coEvery
@@ -22,6 +22,7 @@ class PostponeTaskUseCaseTest {
     private val getTaskByIdInteractor: GetTaskByIdInteractor = mockk(relaxed = true)
     private val updateTaskReminderInteractor: UpdateTaskReminderInteractor = mockk(relaxed = true)
     private val taskReminderManager: TaskReminderManager = mockk(relaxed = true)
+    private val updateTaskUseCase: UpdateTaskUseCase = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -29,6 +30,7 @@ class PostponeTaskUseCaseTest {
             getTaskByIdInteractor = getTaskByIdInteractor,
             updateTaskReminderInteractor = updateTaskReminderInteractor,
             taskReminderManager = taskReminderManager,
+            updateTaskUseCase = updateTaskUseCase,
         )
     }
 
@@ -94,6 +96,34 @@ class PostponeTaskUseCaseTest {
             taskReminderManager.set(
                 taskId = taskId,
                 localDateTime = day.atTime(time),
+            )
+        }
+    }
+
+    @Test
+    fun `Should update task due date when postpone a task`() = runTest {
+        givenTaskWithReminder()
+
+        val taskId = 1L
+        val day = LocalDate.now().plusDays(1)
+        val time = LocalTime.of(21, 0)
+
+        sut.invoke(
+            PostponeTaskUseCase.Params(
+                taskId = taskId,
+                day = day,
+                time = time,
+            )
+        )
+
+        coEvery {
+            updateTaskUseCase.invoke(
+                UpdateTaskUseCase.Params(
+                    taskId = taskId,
+                    name = "Whatever",
+                    date = day,
+                    reminderTime = time
+                )
             )
         }
     }

--- a/feature/settings/src/main/java/com/costular/atomtasks/settings/components/SettingLink.kt
+++ b/feature/settings/src/main/java/com/costular/atomtasks/settings/components/SettingLink.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,8 +14,8 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.costular.atomtasks.core.ui.utils.VariantsPreview
 import com.costular.atomtasks.settings.components.SettingItem
 import com.costular.designsystem.theme.AtomTheme
 
@@ -35,7 +36,7 @@ fun SettingLink(
         },
         title = title,
         end = {
-            Image(
+            Icon(
                 Icons.AutoMirrored.Filled.OpenInNew,
                 contentDescription = null,
                 modifier = Modifier.size(24.dp),
@@ -45,7 +46,7 @@ fun SettingLink(
     )
 }
 
-@Preview(showBackground = true)
+@VariantsPreview
 @Composable
 private fun SettingOptionPrev() {
     AtomTheme {


### PR DESCRIPTION
## Description

There was a product decision issue regarding reminders and task's due date, but it's been tackled in this PR.

### New behavior

Now, when the user postpones the reminder the task's due date will be updated accordingly since it did make no sense to update the reminder date & time but keep the due date so while navigating through the agenda it would be confusing for the user