### PR TITLE
Fix daily reminder being fired always

### DIFF
--- a/core/designsystem/src/main/java/com/costular/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/costular/designsystem/theme/Theme.kt
@@ -9,10 +9,8 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp

--- a/data/src/main/java/com/costular/atomtasks/data/settings/dailyreminder/DailyReminderAlarmSchedulerImpl.kt
+++ b/data/src/main/java/com/costular/atomtasks/data/settings/dailyreminder/DailyReminderAlarmSchedulerImpl.kt
@@ -35,8 +35,11 @@ class DailyReminderAlarmSchedulerImpl @Inject constructor(
     }
 
     override fun remove() {
-        checkNotNull(alarmManager)
-
+        alarmManager?.let { alarmManager ->
+            buildDailyReminderPendingIntent().also {
+                alarmManager.cancel(it)
+            }
+        }
     }
 
     private fun buildDailyReminderPendingIntent(): PendingIntent =

--- a/data/src/main/java/com/costular/atomtasks/data/settings/dailyreminder/DailyReminderWorker.kt
+++ b/data/src/main/java/com/costular/atomtasks/data/settings/dailyreminder/DailyReminderWorker.kt
@@ -9,6 +9,7 @@ import com.costular.atomtasks.core.usecase.EmptyParams
 import com.costular.atomtasks.notifications.DailyReminderNotificationManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.firstOrNull
 
 @HiltWorker
 class DailyReminderWorker @AssistedInject constructor(
@@ -16,9 +17,14 @@ class DailyReminderWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val dailyReminderNotificationManager: DailyReminderNotificationManager,
     private val syncDailyReminderUseCase: SyncDailyReminderUseCase,
+    private val observeDailyReminderUseCase: ObserveDailyReminderUseCase
 ) : CoroutineWorker(appContext, workerParams) {
     override suspend fun doWork(): Result {
         return try {
+            if (observeDailyReminderUseCase.invoke(Unit).firstOrNull()?.isEnabled == false) {
+                return Result.success()
+            }
+
             dailyReminderNotificationManager.showDailyReminderNotification()
             // Re-schedule future daily reminders
             syncDailyReminderUseCase.invoke(EmptyParams)


### PR DESCRIPTION
# Description
There was a bug with the daily reminder that was being called every time, no matter if the setting was enabled or disabled by the user.

Only show daily reminder notification when setting is enabled

Also, to prevent executing unnecessary code and reduce the resources usage now the alarm gets canceled when the setting is disabled